### PR TITLE
Add SOTD making clear draft status, not yet submitted

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@
       <p>In addition to this specification there is a note on <a href="https://docs.google.com/document/d/1oyTM3NPjQOOohTqkjfq1klHalfcEn5w9Ull0_wadbJw/edit?usp=sharing">Web Thing API Protocol Bindings</a> which proposes non-normative bindings of the Web Thing API to various existing IoT protocols. There is also a document describing <a href="https://docs.google.com/document/d/1H3coHbb3Bwd02_NJi4KEBONByUkq92_HsTk1IpfmACY/edit?usp=sharing">Web of Things Integration Patterns</a> which provides advice on different design patterns for integrating connected devices with the Web of Things, and where each pattern is most appropriate.</p>
     </section>
     <section id='sotd'>
-      <p>
+      <p>This document is a draft being prepared for submission; it has not yet been submitted to W3C.
 
       </p>
     </section>


### PR DESCRIPTION
Because W3C process requires a formal response to Member Submissions, it's useful to let readers know this hasn't yet been formally submitted. Thanks!

I believe the WG and W3C team have been discussing the substance already. 