### PR TITLE
Align WS API with REST API

### DIFF
--- a/index.html
+++ b/index.html
@@ -480,7 +480,7 @@ Sec-WebSocket-Protocol: webthing</pre>
     </section>
     <section>
       <h3><code>requestAction</code> message</h3>
-      <p>The <code>requestAction</code> message type is sent from a web client to a Web Thing to request an action be carried out on a Web Thing. This is equivalent to a <code>POST</code> request on an Actions resource URL using the REST API, but multiple actions can be requested at the same time or in quick succession over an open socket.</p>
+      <p>The <code>requestAction</code> message type is sent from a web client to a Web Thing to request an action be carried out on a Web Thing. This is equivalent to a <code>POST</code> request on an Actions resource URL using the REST API, but multiple actions can be sent in quick succession over an open socket.</p>
       <div class="example">
         <div class="example-title marker">
           Example
@@ -488,7 +488,7 @@ Sec-WebSocket-Protocol: webthing</pre>
         <pre>{
   "messageType": "requestAction",
   "data": {
-    "goForward": {},
+    "name": "goForward"
   }
 }</pre>
       </div>
@@ -503,7 +503,7 @@ Sec-WebSocket-Protocol: webthing</pre>
         <pre>{
   "messageType": "addEventSubscription",
   "data": {
-    "motion": {}
+    "name": "motion"
   }
 }</pre>
       </div>
@@ -533,10 +533,9 @@ Sec-WebSocket-Protocol: webthing</pre>
         <pre>{
   "messageType": "actionStatus",
   "data": {
-    "grab": {
-      "href": "/actions/123e4567-e89b-12d3-a456-426655",
-      "status": "completed"
-    }
+    "name": "grab",
+    "href": "/actions/123e4567-e89b-12d3-a456-426655",
+    "status": "completed"
   }
 }</pre>
       </div>
@@ -551,9 +550,8 @@ Sec-WebSocket-Protocol: webthing</pre>
         <pre>{
   "messageType": "event",
   "data": {
-    "motion": {
-      "timestamp": "2017-01-24T13:02:45+00:00"
-    }
+    "name": "motion",
+    "timestamp": "2017-01-24T13:02:45+00:00"
   }
 }</pre>
       </div>


### PR DESCRIPTION
References to named events and actions in the REST API use the "name"
field and have one JSON object per named item. Previously, the WS API
inconsistently used the name parameter as the key for a JSON object
contained the remaining key-value pairs of the named item. This uses the
REST API's approach throughout the WS API, losing the ability to
represent multiple named items in one API response.