### PR TITLE
Change links member to array of link relations - closes #67 closes #68

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,12 +93,29 @@
       "description": "Going down for reboot"
     }
   },
-  "links": {
-    "properties": "/thing/pi/properties",
-    "actions": "/things/pi/actions",
-    "events": "/things/pi/events",
-    "websocket": "wss://mywebthingserver.com/things/pi"
-  }
+  "links": [
+    {
+      "rel": "properties",
+      "href": "/things/pi/properties"
+    },
+    {
+      "rel": "actions",
+      "href": "/things/pi/actions"
+    },
+    {
+      "rel": "events",
+      "href": "/things/pi/events"
+    },
+    {
+      "rel": "alternate",
+      "href": "wss://mywebthingserver.com/things/pi"
+    },
+    {
+      "rel": "alternate",
+      "mediaType": "text/html",
+      "href": "/things/pi"
+    }
+  ]
 }
         </pre>
       </div>
@@ -129,7 +146,7 @@
       </section>
       <section>
         <h3><code>links</code> member</h3>
-        <p>The links member provides a map of URLs for Properties, Actions and Events resources. It can also contain a WebSocket URL to be used for the Thing's WebSocket API. Entries in this map have a key which can be one of "properties", "actions", "events" or "websocket" and a string value representing a URL.</p>
+        <p>The links member provides an array of link relations (<a href="https://tools.ietf.org/html/rfc5988">RFC 5988</a>) to other resources of a thing. Links can include a link relation type (<code>rel</code>) and an optional media type (<code>mediaType</code>). Examples of links include URLs to get all current property values (<code>"rel":"properties"</code>), a queue of all thing action requests (<code>"rel":"actions"</code>) and a list of all recent events (<code>"rel":"events"</code>). It can also include links to alternate representations of a thing such as a WebSocket API endpoint or an HTML user interface (<code>"rel":"alternate"</code>).</p>
       </section>
       <section>
         <h3><code>Property</code> object</h3>
@@ -202,12 +219,29 @@ Accept: application/json</pre>
       "description": "Going down for reboot"
     }
   },
-  "links": {
-    "properties": "/thing/pi/properties",
-    "actions": "/things/pi/actions",
-    "events": "/things/pi/events",
-    "websocket": "wss://mywebthingserver.com/things/pi"
-  }
+  "links": [
+    {
+      "rel": "properties",
+      "href": "/things/pi/properties"
+    },
+    {
+      "rel": "actions",
+      "href": "/things/pi/actions"
+    },
+    {
+      "rel": "events",
+      "href": "/things/pi/events"
+    },
+    {
+      "rel": "alternate",
+      "href": "wss://mywebthingserver.com/things/pi"
+    },
+    {
+      "rel": "alternate",
+      "mediaType": "text/html",
+      "href": "/things/pi"
+    }
+  ]
 }</pre>
         </div>
     </section>
@@ -1157,12 +1191,29 @@ Sec-WebSocket-Protocol: webthing</pre>
       "description": "Your toast is ready!"
     }
   },
-  "links": {
-    "properties": "/properties",
-    "actions": "/actions",
-    "events": "/events",
-    "websocket": "wss://toaster.smith.home"
-  }
+  "links": [
+    {
+      "rel": "properties",
+      "href": "/properties"
+    },
+    {
+      "rel": "actions",
+      "href": "/actions"
+    },
+    {
+      "rel": "events",
+      "href": "/events"
+    },
+    {
+      "rel": "alternate",
+      "href": "wss://toaster.smith.home"
+    },
+    {
+      "rel": "alternate",
+      "mediaType": "text/html",
+      "href": "/"
+    }
+  ]
 }</pre>
         </div>
         <p>The <code>@context</code> property provides an IRI which defines a globally unique "context" within which types are defined. The optional <code>@type</code> property specifies a Web Thing type from that context to be applied to the thing being described.</p>


### PR DESCRIPTION
The consensus at the W3C (see https://github.com/w3c/wot-thing-description/issues/109) seems to be for a top level `links` member of the Thing Description to be an array which represents link relations along the lines of [RFC 5988](https://tools.ietf.org/html/rfc5988). That means links can have a `rel`, a `href` and a `mediaType`.

This is quite a lot more verbose than the current approach in our spec, but it is more flexible and builds on existing standards. For example it can be used to provide a link to an HTML UI for the thing or alternate resources using different formats and protocols.

I don't think we've actually implemented the links member in our gateway implementation yet, but it may have been implemented in some device framework implementations?

What do you think of this approach?

One thing I'm not sure about is what "rel" to use in various places. We might want to register "properties", "actions" and "events" with [IANA](https://www.iana.org/assignments/link-relations/link-relations.xhtml) as new link relation types for example.

Note that the W3C WG is also arguing to make the links on individual properties and events into arrays of link relations too, but I've filed a separate issue for that (#73) as we may want to do one but not the other.