### PR TITLE
Define action arguments and event payloads - closes #17

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,68 +58,78 @@
     <section>
       <h2>Web Thing Description</h2>
       <p>The Thing Description provides a vocabulary for describing physical devices connected to the World Wide Web in a machine readable format with a default JSON encoding.</p>
-      <p><strong>Example</strong></p>
-      <div class="example">
-        <pre>
+      <pre class="example" title="Thing Description">
 {
-  "name":"WoT Pi",
+  "name":"My Lamp",
   "type": "thing",
-  "description": "A WoT-connected Raspberry Pi",
+  "description": "A web connected lamp",
   "properties": {
-    "temperature": {
-      "type": "number",
-      "unit": "celsius",
-      "description": "An ambient temperature sensor",
-      "href": "/things/pi/properties/temperature"
-    },
-    "humidity": {
-      "type": "number",
-      "unit": "percent",
-      "href": "/things/pi/properties/humidity"
-    },
-    "led": {
+    "on": {
       "type": "boolean",
-      "description": "A red LED",
-      "href": "/things/pi/properties/led"
+      "description": "Whether the lamp is turned on",
+      "href": "/things/lamp/properties/on"
+    },
+    "level" : {
+      "type": "number",
+      "description": "The level of light from 0-100",
+      "minimum" : 0,
+      "maximum" : 100,
+      "href": "/things/lamp/properties/level"
     }
   },
   "actions": {
-    "reboot": {
-      "description": "Reboot the device"
+    "fade": {
+      "description": "Fade the lamp to a given level",
+      "input": {
+        "type": "object",
+        "properties": {
+          "level": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 100
+          },
+          "duration": {
+            "type": "number",
+            "unit": "milliseconds"
+          }
+        }
+      },
+      "href": "/things/lamp/actions/fade"
     }
   },
   "events": {
-    "reboot": {
-      "description": "Going down for reboot"
+    "overheated": {
+      "type": "number",
+      "unit": "celcius",
+      "description": "The lamp has exceeded its safe operating temperature",
+      "href": "/things/lamp/events/overheated"
     }
   },
   "links": [
     {
       "rel": "properties",
-      "href": "/things/pi/properties"
+      "href": "/things/lamp/properties"
     },
     {
       "rel": "actions",
-      "href": "/things/pi/actions"
+      "href": "/things/lamp/actions"
     },
     {
       "rel": "events",
-      "href": "/things/pi/events"
+      "href": "/things/lamp/events"
     },
     {
       "rel": "alternate",
-      "href": "wss://mywebthingserver.com/things/pi"
+      "href": "wss://mywebthingserver.com/things/lamp"
     },
     {
       "rel": "alternate",
       "mediaType": "text/html",
-      "href": "/things/pi"
+      "href": "/things/lamp"
     }
   ]
 }
         </pre>
-      </div>
-
       <section>
         <h3><code>name</code> member</h3>
         <p>The name member is a user friendly string which describes the device. This can be set to any value by the device creator and may include a brand name or model number.</p>
@@ -138,7 +148,7 @@
       </section>
       <section>
         <h3><code>actions</code> member</h3>
-        <p>The actions member is a map of action objects which describe functions that can be carried out on a device. Actions are used when the setting of properties is not sufficient to affect a required change in state. This may be used to describe a function which manipulates multiple properties or accepts arguments and has a different effect depending on which arguments are provided. An example might include a "reboot" action which power cycles a device.</p>
+        <p>The actions member is a map of action objects which describe functions that can be carried out on a device. Actions are used when the setting of a property alone is not sufficient to affect a required change in state. This may be used to describe a function which takes a period of time to complete, manipulates multiple properties, or has a different outcome based on provided arguments or current state. An example might include a "fade" action which has a specified "duration" or a "reboot" action which power cycles a device.</p>
       </section>
       <section>
         <h3><code>events</code> member</h3>
@@ -151,20 +161,57 @@
       <section>
         <h3><code>Property</code> object</h3>
         <p>A property object describes an attribute of a Thing and is indexed by a property name. A property description may include its type, unit, description and URL.</p>
+        <pre class="example" title="Property Object">
+"level" : {
+  "type": "number",
+  "description": "The level of light from 0-100",
+  "minimum" : 0,
+  "maximum" : 100,
+  "href": "/things/lamp/properties/level"
+}
+        </pre>
       </section>
       <section>
         <h3><code>Action</code> object</h3>
-        <p>An action object describes a function which can be carried out on a device. An action description may include action parameters and a human friendly description which describes what the action does.</p>
-      </section>
-      <section>
-        <h3><code>Event</code> object</h3>
-        <p>An event object describes a type of event which may be emitted by a device. This may include the type of values which may be included in the event and a human friendly description which describes what the event means.</p>
-      </section>
-      <section>
-        <h3>Alternative Encodings</h3>
-        <p>The default encoding for the Thing description is JSON, but other encodings such as XML, JSON-LD or CBOR may be used. Alternative encodings are beyond the scope of this specification but may be defined separately.</p>
-        <p>References to alternative available encodings may be provided using Link HTTP response headers with the alternate link relation. A client can express a preference for an alternative encoding using HTTP content negotiation.</p>
-      </section>
+        <p>An action object describes a function which can be carried out on a device. An action definition may include an action <code>input</code> with a JSON Schema which specifies one or more parameters, a human friendly <code>description</code> which explains what the action does and an <code>href</code> which provides the URL for a corresponding Action Resource.</p>
+        <pre class="example" title="Action Object">
+"fade": {
+  "description": "Fade the lamp to a given level",
+  "input": {
+    "type": "object",
+    "properties": {
+      "level": {
+        "type: number",
+        "minimum": 0,
+        "maximum": 100
+      },
+      "duration": {
+        "type": "number",
+        "unit": "milliseconds"
+      }
+    }
+  },
+  "href": "/things/lamp/actions/fade"
+}
+      </pre>
+    </section>
+    <section>
+      <h3><code>Event</code> object</h3>
+      <p>An event object describes a kind of event which may be emitted by a device. This may include the <code>type</code> of the event payload (specified using a JSON Schema type), a human friendly <code>description</code> which describes what the event means and an <code>href</code> which provides the URL for a corresponding Event Resource.</p>
+      <pre class="example" title="Event Object">
+"overheated": {
+  "type": "number",
+  "unit": "celcius",
+  "description": "The lamp has exceeded its safe operating temperature",
+  "href": "/things/lamp/events/overheated"
+}
+      </pre>
+    </section>
+    <section>
+      <h3>Alternative Encodings</h3>
+      <p>The default encoding for the Thing description is JSON, but other encodings such as XML, JSON-LD or CBOR may be used. Alternative encodings are beyond the scope of this specification but may be defined separately.</p>
+      <p>References to alternative available encodings may be provided using Link HTTP response headers with the alternate link relation. A client can express a preference for an alternative encoding using HTTP content negotiation.</p>
+    </section>
     </section>
     <section>
       <h2>Web Thing REST API</h2>
@@ -289,120 +336,115 @@ Accept: application/json</pre>
     <section>
       <h3><code>Actions</code> resource</h3>
       <p>An actions resource represents a queue of actions to be executed on a device. A new action is created in the queue with an HTTP POST request and can be deleted from the queue with an HTTP DELETE request. The current status of an action request can be retrieved with an HTTP GET request and updated with an HTTP PUT request.</p>
-      <p><strong>Example: Request an action</strong></p>
-      <div class="example">
-        <div class="example-title marker">
-          Request
-        </div>
-        <pre>POST http://mythingserver.com/things/pi/actions/
+      <p><strong>Action Request</strong></p>
+      <pre class="example" title="Request an action">
+POST https://mythingserver.com/things/lamp/actions/
+Accept: application/json
+
 {
-  "reboot": {}
+  "fade": {
+    "input": {
+      "level": 50,
+      "duration": 2000
+    }
+  }
 }
-Accept: application/json</pre>
-      </div>
-      <div class="example">
-        <div class="example-title marker">
-          Response
-        </div>
-        <pre>201 Created
+      </pre>
+      <pre class="example" title="Response to creating an action request">
+201 Created
+
 {
-  "reboot": {
-    "href": "/things/pi/actions/reboot/123e4567-e89b-12d3-a456-426655"
+  "fade": {
+    "input": {
+      "level": 50,
+      "duration": 2000
+    },
+    "href": "/things/lamp/actions/fade/123e4567-e89b-12d3-a456-426655"
     "status": "pending"
   }
-}</pre>
+}
+      </pre>
+      <p><strong>Actions Queue</strong></p>
+      <pre class="example" title="Get a list of all action requests">
+GET /things/lamp/actions
+Accept: application/json
+      </pre>
       </div>
-      <p><strong>Example: Get a list of action requests</strong></p>
-      <div class="example">
-        <div class="example-title marker">
-          Request
-        </div>
-        <pre>GET /things/pi/actions
-Accept: application/json</pre>
-      </div>
-      <div class="example">
-        <div class="example-title marker">
-          Response
-        </div>
-        <pre>200 OK
+      <pre class="example" title="Action list response">
+200 OK
 [
   {
-    "reboot": {
-      "href": "/things/pi/actions/123e4567-e89b-12d3-a456-426655",
+    "fade": {
+      "input": {
+        "level": 50,
+        "duration": 2000
+      },
+      "href": "/things/lamp/actions/fade/123e4567-e89b-12d3-a456-426655",
       "timeRequested": "2017-01-25T15:01:35+00:00",
       "status": "pending"
     }
   },
   {
-    "reboot": {
-      "href": "/things/pi/actions/153e3567-e89b-12a3-a456-426351",
+    "fade": {
+      "input": {
+        "level": 100,
+        "duration": 2000
+      },
+      "href": "/things/lamp/actions/fade/123e4567-e89b-12d3-a456-426655",
       "timeRequested": "2017-01-24T11:02:45+00:00",
       "timeCompleted": "2017-01-24T11:02:46+00:00",
       "status": "completed"
     }
   }
-]</pre>
-      </div>
-      <p><strong>Example: Get an action request</strong></p>
-      <div class="example">
-        <div class="example-title marker">
-          Request
-        </div>
-        <pre>GET /things/pi/actions/123e4567-e89b-12d3-a456-426655
-Accept: application/json</pre>
-      </div>
-      <div class="example">
-        <div class="example-title marker">
-          Response
-        </div>
-        <pre>200 OK
+]
+      </pre>
+      <p><strong>Action Status</strong></p>
+      <pre class="example" title="Get the status of an action">
+GET /things/lamp/actions/fade/123e4567-e89b-12d3-a456-426655
+Accept: application/json
+      </pre>
+      <pre class="example" title="Action status response">
+200 OK
 {
-  "reboot": {
-    "href": "/things/pi/actions/reboot/123e4567-e89b-12d3-a456-426655",
+  "fade": {
+    "input": {
+      "level": 50,
+      "duration": 2000
+    },
+    "href": "/things/lamp/actions/fade/123e4567-e89b-12d3-a456-426655",
     "timeRequested": "2017-01-25T15:01:35+00:00",
     "status": "pending"
   }
-}</pre>
-      </div>
-      <p><strong>Example: Cancel an action request</strong></p>
-      <div class="example">
-        <div class="example-title marker">
-          Request
-        </div>
-        <pre>DELETE /things/pi/actions/reboot/123e4567-e89b-12d3-a456-426655</pre>
-      </div>
-      <div class="example">
-        <div class="example-title marker">
-          Response
-        </div>
-        <pre>204 No Content
-</pre>
-      </div>
+}
+      </pre>
+      <p><strong>Cancel an Action</strong></p>
+      <pre class="example" title="Cancel an action request response">
+DELETE /things/lamp/actions/fade/123e4567-e89b-12d3-a456-426655
+      </pre>
+      <pre class="example" title="Action cancellation response">
+204 No Content
+      </pre>
     </section>
     <section>
       <h3><code>Events</code> resource</h3>
-      <p>An events resource provides a list of events emitted by a device. An events resource is usually read only.</p>
-      <p><strong>Example: Get a list of events</strong></p>
-      <div class="example">
-        <div class="example-title marker">
-          Request
-        </div>
-        <pre>GET /things/pi/events
-Accept: application/json</pre>
-      </div>
-      <div class="example">
-        <div class="example-title marker">
-          Response
-        </div>
-        <pre>200 OK
+      <p>An events resource provides a log of events recently emitted by a device. An events resource is usually read only.</p>
+      <p><strong>Event Log</strong></p>
+      <pre class="example" title="Events Request">
+GET /things/pi/lamp
+Accept: application/json
+      </pre>
+      <pre class="example" title="Events Response">
+200 OK
 [
   {
-    "reboot": {
+    "overheated": {
+      "data": 102,
       "timestamp": "2017-01-25T15:01:35+00:00"
     }
   },
   {
-    "reboot": {
+    "overheated": {
+      "data": 101,
       "timestamp": "2017-01-24T13:02:45+00:00"
     }
   }


### PR DESCRIPTION
This pull request defines a system for providing arguments for actions and defining payload data for events. It is based on the latest [experimental simplified TD proposal](https://w3c.github.io/wot-thing-description/proposals/simplified-td/#wip-experimental-td) from Siemens and should be backwards compatible because we hadn't defined this yet.

A difference with the [JSON-TD proposal](http://w3c.github.io/wot/proposals/json-td/#action-object) is that rather than define multiple arguments for an action using a "data" object with a key-value pair for each argument, a single "input" field is provided which specifies a single value as a JSON schema. That value could be a primitive type like a "number" or "boolean", or it could be an "object" with nested "properties" in order to support multiple arguments. This approach allows re-using a lot of JSON Schema to define action argument types, aligned with a system to also define types for properties and sub-properties of Things using JSON Schema, and types for event payloads (see below).  Defining an "input" field allows defining an "output" field as well in future.

```
"fade": {
  "description": "Fade the lamp to a given level",
  "input": {
    "type": "object",
    "properties": {
      "level": {
        "type: number",
        "minimum": 0,
        "maximum": 100
      },
      "duration": {
        "type": "number",
        "unit": "milliseconds",
      }
    }
  },
  "href": "/things/lamp/actions/fade"
}
```

This then maps onto an action request in the REST API by adding an "input" field to the action request.

```
POST https://mythingserver.com/things/lamp/actions/
Accept: application/json

{
  "fade": {
    "input": {
      "level": 50,
      "duration": 2000
    }
  }
}
```

Events, like properties, have a top level type which is defined by a JSON Schema (as opposed to an input and output like actions). That type can be a primitive type like a "number" or "boolean" or it can be an object, with multiple nested "properties".

Example with primitive type:
```
"overheated": {
  "type": "number",
  "unit": "celcius",
  "description": "The lamp has exceeded its safe operating temperature",
  "href": "/things/lamp/events/overheated"
}
```

Example with object:
```
"overheated": {
  "type": "object"
  "properties": {
    "temperature": {
      "type": "number",
      "unit": "celcius"
    } 
  }
  "description": "The lamp has exceeded its safe operating temperature",
  "href": "/things/lamp/events/overheated"
}
```

The events resource in the REST API includes the payload "data" for each event instance as per the type defined in the Thing Description. This part is maybe a little bit clunky because the term "data" is not defined in the Thing Description for events, whereas "input" is defined for actions. Does that matter? Should it be called "data" or something else like "detail" (often used in JavaScript events).

Example with primitive type:
```
[
  {
    "overheated": {
      "data": 102,
      "timestamp": "2017-01-25T15:01:35+00:00"
    }
  }
]
```

Example with object:
```
[
  {
    "overheated": {
      "data": {
        "temperature": 102
      },
      "timestamp": "2017-01-25T15:01:35+00:00"
    }
  }
]
```

I've also changed some of the examples to better illustrate these new features.