### PR TITLE
Describe Gateway /things websocket endpoint 

### DIFF
--- a/index.html
+++ b/index.html
@@ -784,7 +784,7 @@ Accept: application/json</pre>
   </section>
   <section>
     <h2>Web Thing WebSocket API</h2>
-      <p>The Web Thing WebSocket API complements the REST API to provide a realtime mechanism to make multiple requests and be notified of events as soon as they happen, by keeping a WebSocket [[!WEBSOCKETS-PROTOCOL]] open on the Web Thing. The "webthing" WebSocket subprotocol defined here has a simple set of message types and a JSON response format consistent with the Web Thing REST API.</p>
+    <p>The Web Thing WebSocket API complements the REST API to provide a realtime mechanism to make multiple requests and be notified of events as soon as they happen, by keeping a WebSocket [[!WEBSOCKETS-PROTOCOL]] open on the Web Thing. The "webthing" WebSocket subprotocol defined here has a simple set of message types and a JSON response format consistent with the Web Thing REST API. Each message may additionally include an <code>id</code> member set to the <code>id</code> of the thing producing the message.</p>
     <section>
       <h3>Protocol Handshake</h3>
       <p>To open a WebSocket on a Thing, an HTTP GET request is upgraded to a WebSocket using a standard WebSocket protocol handshake [[!WEBSOCKETS-PROTOCOL]] and the "webthing" subprotocol. The WebSocket URL for a Web Thing is specified in the links member of the Web Thing Description.</p>
@@ -827,6 +827,7 @@ Sec-WebSocket-Protocol: webthing</pre>
           Example
         </div>
         <pre>{
+  "id": "https://mywebthingserver.com/things/robot",
   "messageType": "setProperty",
   "data": {
     "leftMotor": 100
@@ -842,6 +843,7 @@ Sec-WebSocket-Protocol: webthing</pre>
           Example
         </div>
         <pre>{
+  "id": "https://mywebthingserver.com/things/robot",
   "messageType": "requestAction",
   "data": {
     "goForward": {},
@@ -857,6 +859,7 @@ Sec-WebSocket-Protocol: webthing</pre>
           Example
         </div>
         <pre>{
+  "id": "https://mywebthingserver.com/things/robot",
   "messageType": "addEventSubscription",
   "data": {
     "motion": {}
@@ -872,6 +875,7 @@ Sec-WebSocket-Protocol: webthing</pre>
           Example
         </div>
         <pre>{
+  "id": "https://mywebthingserver.com/things/robot",
   "messageType": "propertyStatus",
   "data": {
     "led": true
@@ -887,6 +891,7 @@ Sec-WebSocket-Protocol: webthing</pre>
           Example
         </div>
         <pre>{
+  "id": "https://mywebthingserver.com/things/robot",
   "messageType": "actionStatus",
   "data": {
     "grab": {
@@ -907,6 +912,7 @@ Sec-WebSocket-Protocol: webthing</pre>
           Example
         </div>
         <pre>{
+  "id": "https://mywebthingserver.com/things/robot",
   "messageType": "event",
   "data": {
     "motion": {
@@ -914,6 +920,37 @@ Sec-WebSocket-Protocol: webthing</pre>
     }
   }
 }</pre>
+        </div>
+      </section>
+    </section>
+    <section>
+      <h2>Gateway WebSocket API</h2>
+      <p>The Gateway WebSocket API acts as a broader version of the <a href="#web-thing-websocket-api">Web Thing WebSocket API</a> by allowing the client to open one WebSocket connection per Gateway instead of per Thing. The connection then acts as a multiplex of all the Gateway's Things' WebSocket connections. The <code>id</code> member is required for this channel to allow both the Gateway and the WebSocket client to determine with which Thing each message is associated.
+      <section>
+        <h3>Protocol Handshake</h3>
+        <p>To open a WebSocket on a Gateway, an HTTP GET request is upgraded to a WebSocket using a standard <a href="https://tools.ietf.org/html/rfc6455">WebSocket protocol</a> handshake and the "webthing" subprotocol. The WebSocket URL for a Gateway is the "/things" endpoint.</p>
+        <div class="example">
+          <div class="example-title marker">
+            Request
+          </div>
+          <pre>GET wss://mywebthingserver.com/things
+Host: mywebthingserver.com
+Origin: https://mywebthingserver.com
+Upgrade: websocket
+Connection: Upgrade
+Sec-WebSocket-Key: x3JJHMbDL1EzLkh9GBhXDw==
+Sec-WebSocket-Protocol: webthing
+Sec-WebSocket-Version: 13</pre>
+        </div>
+        <div class="example">
+          <div class="example-title marker">
+            Response
+          </div>
+          <pre>HTTP 101 Switching Protocols
+Upgrade: websocket
+Connection: Upgrade
+Sec-WebSocket-Accept: HSmrc0sMlYUkAGmm5OPpG2HaGWk=
+Sec-WebSocket-Protocol: webthing</pre>
         </div>
       </section>
     </section>

--- a/index.html
+++ b/index.html
@@ -364,7 +364,7 @@
           <div class="example-title marker">
             <span>Request</span>
           </div>
-          <pre>GET http://mythingserver.com/things/pi
+          <pre>GET http://mywebthingserver.com/things/pi
 Accept: application/json</pre>
         </div>
         <div class="example">
@@ -445,7 +445,7 @@ Accept: application/json</pre>
         <div class="example-title marker">
           Request
         </div>
-        <pre>GET http://mythingserver.com/things/pi/properties
+        <pre>GET http://mywebthingserver.com/things/pi/properties
 Accept: application/json</pre>
       </div>
       <div class="example">
@@ -470,7 +470,7 @@ Accept: application/json</pre>
         <div class="example-title marker">
           Request
         </div>
-        <pre>GET http://mythingserver.com/things/pi/properties/temperature
+        <pre>GET http://mywebthingserver.com/things/pi/properties/temperature
 Accept: application/json</pre>
       </div>
       <div class="example">
@@ -487,7 +487,7 @@ Accept: application/json</pre>
         <div class="example-title marker">
           Request
         </div>
-        <pre>PUT http://mythingserver.com/things/pi/properties/led
+        <pre>PUT http://mywebthingserver.com/things/pi/properties/led
 {
   "led": true
 }
@@ -510,7 +510,7 @@ Accept: application/json</pre>
       <p>Any action supported by the thing can be requested via this top level action queue. If an unsupported action type is requested, the server should respond with a <code>400 Bad Request</code> response.</p>
       <p><strong>Action Request</strong></p>
       <pre class="example" title="Request an action">
-POST https://mythingserver.com/things/lamp/actions/
+POST https://mywebthingserver.com/things/lamp/actions/
 Accept: application/json
 
 {
@@ -573,7 +573,7 @@ Accept: application/json
       <p>If a client tries to request an action of another type via this resource, the server should respond with a <code>400 Bad Request</code> response.</p>
       <p><strong>Action Request</strong></p>
       <pre class="example" title="Request an action">
-POST https://mythingserver.com/things/lamp/actions/fade
+POST https://mywebthingserver.com/things/lamp/actions/fade
 Accept: application/json
 
 {
@@ -792,9 +792,9 @@ Accept: application/json</pre>
         <div class="example-title marker">
           Request
         </div>
-        <pre>GET wss://mythingserver.com/things/robot
-Host: mythingserver.com
-Origin: https://mythingserver.com
+        <pre>GET wss://mywebthingserver.com/things/robot
+Host: mywebthingserver.com
+Origin: https://mywebthingserver.com
 Upgrade: websocket
 Connection: Upgrade
 Sec-WebSocket-Key: x3JJHMbDL1EzLkh9GBhXDw==
@@ -816,7 +816,7 @@ Sec-WebSocket-Protocol: webthing</pre>
         <div class="example-title marker">
           Example
         </div>
-        <pre>const socket = new WebSocket('wss://mywebthingserver/things/robot', 'webthing');</pre>
+        <pre>const socket = new WebSocket('wss://mywebthingserver.com/things/robot', 'webthing');</pre>
       </div>
     </section>
     <section>


### PR DESCRIPTION
Mirrors current gateway implementation and documents optional addition
of `id` to WS messages.

Also replaces mythingserver with mywebthingserver for consistency